### PR TITLE
Fix depend missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   sensor_msgs
   geometry_msgs
-  uuid_msgs)
+  uuid_msgs
+)
 
 include_directories(include)
 
@@ -30,6 +31,7 @@ generate_messages(DEPENDENCIES
   std_msgs
   sensor_msgs
   geometry_msgs
+  uuid_msgs
 )
 
 catkin_package(CATKIN_DEPENDS
@@ -37,6 +39,7 @@ catkin_package(CATKIN_DEPENDS
   std_msgs
   sensor_msgs
   geometry_msgs
+  uuid_msgs
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
On `CMakeLists.txt` there are dependencies missing.
Especially for `generate_messages()` and `catkin_package()` functions.
So, I added `uuid_msgs` to fix dependencies.